### PR TITLE
Allow endpoint URL to be passed into getBodyEnd for testing purposes

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -2,7 +2,7 @@ import { Metadata } from "./types";
 
 const apiURL = "https://contributions.guardianapis.com/epic";
 
-export const getBodyEnd = (meta: Metadata, useUrl?: string): Promise<Response> => {
+export const getBodyEnd = (meta: Metadata, url: string = apiURL): Promise<Response> => {
   const json = JSON.stringify(meta);
   return fetch(useUrl || apiURL, {
     method: "post",

--- a/client.ts
+++ b/client.ts
@@ -2,9 +2,9 @@ import { Metadata } from "./types";
 
 const apiURL = "https://contributions.guardianapis.com/epic";
 
-export const getBodyEnd = (meta: Metadata): Promise<Response> => {
+export const getBodyEnd = (meta: Metadata, useUrl?: string): Promise<Response> => {
   const json = JSON.stringify(meta);
-  return fetch(apiURL, {
+  return fetch(useUrl || apiURL, {
     method: "post",
     headers: { "Content-Type": "application/json" },
     body: json

--- a/client.ts
+++ b/client.ts
@@ -4,7 +4,7 @@ const apiURL = "https://contributions.guardianapis.com/epic";
 
 export const getBodyEnd = (meta: Metadata, url: string = apiURL): Promise<Response> => {
   const json = JSON.stringify(meta);
-  return fetch(useUrl || apiURL, {
+  return fetch(url, {
     method: "post",
     headers: { "Content-Type": "application/json" },
     body: json


### PR DESCRIPTION
This allows the API URL to be passed into the function as an argument, so we can easily call the service running on our local environments. Useful for testing only.