### PR TITLE
Update getViewLog return type

### DIFF
--- a/contributions/viewLog.ts
+++ b/contributions/viewLog.ts
@@ -17,11 +17,6 @@ import { get as getItem, set as setItem } from '../lib/localStorage';
 const viewKey = 'gu.contributions.views';
 const viewLog = getItem(viewKey) || [];
 
-// interface ViewLog {
-//   date: number;
-//   testId: string;
-// }
-
 // Hard limit on the number of entries to keep in the viewLog.
 const maxLogEntries = 50;
 

--- a/contributions/viewLog.ts
+++ b/contributions/viewLog.ts
@@ -10,16 +10,17 @@
 // NOTE: this is a short term approach to ensure backwards compatibility with
 // the Frontend view log. As Slot Machine grows, we'll move towards a more
 // centralised way of managing the slot state from an upper level.
+import { ViewLog } from '../types';
 import { get as getItem, set as setItem } from '../lib/localStorage';
 
 // The key must be backwards compatible with Frontend.
 const viewKey = 'gu.contributions.views';
 const viewLog = getItem(viewKey) || [];
 
-interface ViewLog {
-  date: number;
-  testId: string;
-}
+// interface ViewLog {
+//   date: number;
+//   testId: string;
+// }
 
 // Hard limit on the number of entries to keep in the viewLog.
 const maxLogEntries = 50;
@@ -27,8 +28,11 @@ const maxLogEntries = 50;
 /**
  * Return the entire viewLog.
  */
-export const getViewLog = (): ViewLog[] | null => {
-  return getItem(viewKey);
+export const getViewLog = (): ViewLog | void => {
+  // Return undefined instead of null if view log does not exist
+  // Needed because the localStorage API returns null for non-existing keys
+  // but Contributions API expects a view log or undefined.
+  return getItem(viewKey) || undefined;
 };
 
 /**

--- a/contributions/viewLog.ts
+++ b/contributions/viewLog.ts
@@ -28,7 +28,7 @@ const maxLogEntries = 50;
 /**
  * Return the entire viewLog.
  */
-export const getViewLog = (): ViewLog | void => {
+export const getViewLog = (): ViewLog | undefined => {
   // Return undefined instead of null if view log does not exist
   // Needed because the localStorage API returns null for non-existing keys
   // but Contributions API expects a view log or undefined.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/slot-machine-client",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Client lib for Slot Machine",
   "author": "Nicolas Long <nicolas.long@theguardian.com>",
   "license": "MIT",

--- a/types.ts
+++ b/types.ts
@@ -21,7 +21,8 @@ interface View {
   date: number;
   testId: string;
 }
-type ViewLog = View[];
+
+export type ViewLog = View[];
 
 type Targeting = {
   contentType: string;


### PR DESCRIPTION
Updates the return types for the `getViewLog` function so we always return either the `viewLog` or `undefined` (as opposed to `null` which is default for non-existent local storage keys).