### PR TITLE
Add mvtid

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "publishToNPM": "yarn version --patch && yarn build && yarn publish --access public"
+    "publishToNPM": "yarn version --patch && yarn build && yarn publish --access public",
+    "test": "jest"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",

--- a/types.ts
+++ b/types.ts
@@ -32,6 +32,7 @@ type Targeting = {
   isPaidContent: boolean;
   tags: Tag[];
   epicViewLog?: ViewLog;
+  mvtId: number;
 
   // Note, it turns out that showSupportMessaging (defined in the Members Data
   // API) does not capture every case of recurring contributors or last


### PR DESCRIPTION
We need the mvt (multi-variate testing) ID for test support, e.g. see: https://github.com/guardian/contributions-service/pull/54.