### PR TITLE
Add temporary comparison endpoint

### DIFF
--- a/contributions/compare.ts
+++ b/contributions/compare.ts
@@ -1,0 +1,24 @@
+import { Targeting } from "../types";
+
+interface CompareMeta {
+  targeting: Targeting;
+  expectedTest: string;
+  expectedVariant: string;
+}
+
+const apiURL =
+  "https://contributions.guardianapis.com/epic/compare-variant-decision";
+
+// Temporary helper to evaluate our variant logic server-side
+// No useful response expected (so discard).
+export const compareVariantDecision = (
+  meta: CompareMeta,
+  url: string = apiURL
+): Promise<Response> => {
+  const json = JSON.stringify(meta);
+  return fetch(url, {
+    method: "post",
+    headers: { "Content-Type": "application/json" },
+    body: json
+  });
+};

--- a/contributions/compare.ts
+++ b/contributions/compare.ts
@@ -1,24 +1,23 @@
-import { Targeting } from "../types";
+import { Targeting } from '../types';
 
 interface CompareMeta {
-  targeting: Targeting;
-  expectedTest: string;
-  expectedVariant: string;
+    targeting: Targeting;
+    expectedTest: string;
+    expectedVariant: string;
 }
 
-const apiURL =
-  "https://contributions.guardianapis.com/epic/compare-variant-decision";
+const apiURL = 'https://contributions.guardianapis.com/epic/compare-variant-decision';
 
 // Temporary helper to evaluate our variant logic server-side
 // No useful response expected (so discard).
 export const compareVariantDecision = (
-  meta: CompareMeta,
-  url: string = apiURL
+    meta: CompareMeta,
+    url: string = apiURL,
 ): Promise<Response> => {
-  const json = JSON.stringify(meta);
-  return fetch(url, {
-    method: "post",
-    headers: { "Content-Type": "application/json" },
-    body: json
-  });
+    const json = JSON.stringify(meta);
+    return fetch(url, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: json,
+    });
 };

--- a/contributions/compare.ts
+++ b/contributions/compare.ts
@@ -10,14 +10,11 @@ const apiURL = 'https://contributions.guardianapis.com/epic/compare-variant-deci
 
 // Temporary helper to evaluate our variant logic server-side
 // No useful response expected (so discard).
-export const compareVariantDecision = (
-    meta: CompareMeta,
-    url: string = apiURL,
-): Promise<Response> => {
+export const compareVariantDecision = (meta: CompareMeta, url: string = apiURL): void => {
     const json = JSON.stringify(meta);
-    return fetch(url, {
+    fetch(url, {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
         body: json,
-    });
+    }).catch(() => {});
 };

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
-export { getBodyEnd } from './slots';
+export { getBodyEnd } from "./slots";
 export {
   getViewLog,
   logView,
   getNumViewsInPreviousDays
-} from './contributions/viewLog';
+} from "./contributions/viewLog";
+export { compareVariantDecision } from "./contributions/compare";

--- a/slots.ts
+++ b/slots.ts
@@ -1,6 +1,6 @@
-import { Metadata } from './types';
+import { Metadata } from "./types";
 
-const apiURL = 'https://contributions.guardianapis.com/epic';
+const apiURL = "https://contributions.guardianapis.com/epic";
 
 export const getBodyEnd = (
   meta: Metadata,
@@ -8,8 +8,8 @@ export const getBodyEnd = (
 ): Promise<Response> => {
   const json = JSON.stringify(meta);
   return fetch(url, {
-    method: 'post',
-    headers: { 'Content-Type': 'application/json' },
+    method: "post",
+    headers: { "Content-Type": "application/json" },
     body: json
   });
 };

--- a/types.ts
+++ b/types.ts
@@ -24,7 +24,7 @@ interface View {
 
 export type ViewLog = View[];
 
-type Targeting = {
+export type Targeting = {
   contentType: string;
   sectionName: string;
   shouldHideReaderRevenue: boolean;


### PR DESCRIPTION
**UPDATE:** now  ready for review.

See https://github.com/guardian/contributions-service/pull/54 for context.

(WIP - this is about to change as tracking https://github.com/guardian/contributions-service/pull/56 so not ready for review yet.)