### PR TITLE
Adds a function to initialise the Epic Reminder on the platform

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-export { getBodyEnd } from './slots';
+export { getBodyEnd, initSlot } from './slots';
 export { getWeeklyArticleHistory, incrementWeeklyArticleCount } from './history';
 export { getViewLog, logView, getNumViewsInPreviousDays } from './contributions/viewLog';
 export { compareVariantDecision } from './contributions/compare';

--- a/slots.ts
+++ b/slots.ts
@@ -32,13 +32,17 @@ export const initSlot = (): void => {
     // .submitting
     // .error
     // .success
-    const epicReminder = document.querySelector('#epicReminder');
+    const epicReminder = document.querySelector<HTMLElement>(
+        '[data-target="contributions-epic-reminder"]',
+    );
     if (epicReminder) {
-        const epicReminderSubmit = document.querySelector('#epicReminderSubmit');
+        const epicReminderSubmit = document.querySelector<HTMLButtonElement>(
+            '[data-target="submit"]',
+        );
         if (epicReminderSubmit) {
             epicReminderSubmit.addEventListener('click', () => {
                 const epicReminderInput = document.querySelector<HTMLInputElement>(
-                    '#epicReminderInput',
+                    '[data-target="input"]',
                 );
                 if (epicReminderInput) {
                     // Valid input field

--- a/slots.ts
+++ b/slots.ts
@@ -33,8 +33,6 @@ export const initSlot = (): void => {
                         reminderDate: epicReminderSubmit.getAttribute('data-reminder-date'),
                         isPreContribution: true,
                     });
-                    console.log('Reminder Form: ');
-                    console.log(values);
                     fetch(reminderUrl, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },

--- a/slots.ts
+++ b/slots.ts
@@ -2,6 +2,15 @@ import { Metadata } from './types';
 
 const apiURL = 'https://contributions.guardianapis.com/epic';
 
+const reminderUrl = 'https://contribution-reminders-code.support.guardianapis.com/remind-me'; // CODE
+
+const checkForErrors = (response: any) => {
+    if (!response.ok) {
+        throw Error(response.statusText);
+    }
+    return response;
+};
+
 export const getBodyEnd = (meta: Metadata, url: string = apiURL): Promise<Response> => {
     const json = JSON.stringify(meta);
     return fetch(url, {
@@ -9,4 +18,39 @@ export const getBodyEnd = (meta: Metadata, url: string = apiURL): Promise<Respon
         headers: { 'Content-Type': 'application/json' },
         body: json,
     });
+};
+
+export const initSlot = (): void => {
+    const epicReminder = document.querySelector('#epicReminder');
+    if (epicReminder) {
+        const epicReminderSubmit = document.querySelector('#epicReminderSubmit');
+        if (epicReminderSubmit) {
+            epicReminderSubmit.addEventListener('click', () => {
+                const epicReminderInput = document.querySelector('#epicReminderInput');
+                if (epicReminderInput && epicReminderInput.value) {
+                    const values = JSON.stringify({
+                        email: epicReminderInput.value,
+                        reminderDate: epicReminderSubmit.getAttribute('data-reminder-date'),
+                        isPreContribution: true,
+                    });
+                    console.log('Reminder Form: ');
+                    console.log(values);
+                    fetch(reminderUrl, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: values,
+                    })
+                        .then(checkForErrors)
+                        .then(response => response.json())
+                        .then(json => {
+                            if (json !== 'OK') {
+                                throw Error('Server error');
+                            }
+                            epicReminder.classList.add('submitted');
+                        })
+                        .catch(error => console.error('Error: ', error));
+                }
+            });
+        }
+    }
 };


### PR DESCRIPTION
## NOTES
This function is being moved to the Contributions service so might be better to not review just yet.

## What's in this PR?
Exporting a function that can be run on the platform after injecting an Epic which requires interaction via JS. Uses pure JS to avoid framework/library assumptions. Currently only adds interaction and form submission to Epics set to have a 'reminder' field.

## Why?
Because some Epic variants are interactive and so we need to run some JS on them once they've injected in the DOM by the platform.