### PR TITLE
Rename Slot Machine to Automat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# @guardian/slot-machine-client
+# @guardian/automat-client
 
-A basic (JS) client for Slot Machine. If you are reading this and don't know
-what Slot Machine is, this library is probably not useful for you.
+A basic (JS) client for Automat. If you are reading this and don't know
+what Automat is, this library is probably not useful for you.
 
 ## Local dev
 
@@ -11,12 +11,12 @@ what Slot Machine is, this library is probably not useful for you.
 $ yarn dev
 ```
 
-### Point a project to your local version of slot-machine-client
+### Point a project to your local version of automat-client
 
 With [`yarn link`] you can develop against a locally checked out version of
 this client:
 
-In your local checkout of `slot-machine-client`:
+In your local checkout of `automat-client`:
 
 ```
 $ yarn link
@@ -25,13 +25,13 @@ $ yarn link
 And then in the project consuming the client:
 
 ```
-$ yarn link "@guardian/slot-machine-client"
+$ yarn link "@guardian/automat-client"
 ```
 
 To revert back to using the published version of the package:
 
 ```
-$ yarn unlink "@guardian/slot-machine-client"
+$ yarn unlink "@guardian/automat-client"
 $ yarn install --force
 ```
 

--- a/contributions/viewLog.ts
+++ b/contributions/viewLog.ts
@@ -1,14 +1,14 @@
 // This is a set of helper functions to manage the Epic View Log on the client.
 // The view log is an object persisted in localStorage which contains an array
 // of objects with each entry containing the test ID and the timestamp each Epic
-// view, so that Slot Machine knows which Epics a user has seen and can then
+// view, so that Automat knows which Epics a user has seen and can then
 // integrate this data back in the targeting logic.
 // As a minimum, we expect the platform to call:
 // - getViewLog when building the payload to call the Contributions service.
 // - logView when rendering the Epic that has been fetched from the
 // Contributions service.
 // NOTE: this is a short term approach to ensure backwards compatibility with
-// the Frontend view log. As Slot Machine grows, we'll move towards a more
+// the Frontend view log. As Automat grows, we'll move towards a more
 // centralised way of managing the slot state from an upper level.
 import { ViewLog } from '../types';
 import { get as getItem, set as setItem } from '../lib/localStorage';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@guardian/slot-machine-client",
+  "name": "@guardian/automat-client",
   "version": "0.2.7",
-  "description": "Client lib for Slot Machine",
+  "description": "Client lib for Automat",
   "author": "Nicolas Long <nicolas.long@theguardian.com>",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
I don't have permission to rename this repo, but this updates all internal references to Slot Machine -> Automat. I've left the GH repo url in the package.json as-is until the rename has happened (which I think could be in a future PR, after the NPM package name update).

I think it makes sense to continue with the same version numbering scheme we currently have (i.e. not to reset to 0.0.1 when we rename). Interested in other's thoughts on this.

## TODO

- [ ] Rename GitHub Repo
- [ ] Publish new NPM package `automat-client`
- [ ] Deprecate old NPM package