### PR TITLE
Remove some tracking params from automat payload

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -7,9 +7,6 @@ type Tracking = {
     ophanComponentId: string;
     platformId: string;
     clientName: string;
-    campaignCode: string;
-    abTestName: string;
-    abTestVariant: string;
     referrerUrl: string;
 };
 


### PR DESCRIPTION
**Note: not to be merged before guardian/contributions-service#71.**

Once the contributions service is in charge of selecting tests/variants dynamically, it doesn’t make sense for the platform to pass these fields. Instead we’ll return them from the contributions service as part of the metadata in the body.