### PR TITLE
Remove localisation from epic payload

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -1,7 +1,3 @@
-type Localisation = {
-    countryCode?: string;
-};
-
 type Tracking = {
     ophanPageId: string;
     ophanComponentId: string;
@@ -52,6 +48,5 @@ export type Targeting = {
 
 export type Metadata = {
     tracking: Tracking;
-    localisation: Localisation;
     targeting: Targeting;
 };


### PR DESCRIPTION
The countryCode is now specified as part of the targeting object by both DCR and frontend, so we can go ahead and remove the localisation object.