### PR TITLE
Made sectionName optional

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -31,6 +31,7 @@ export type Targeting = {
     shouldHideReaderRevenue: boolean;
     isMinuteArticle: boolean;
     isPaidContent: boolean;
+    isSensitive?: boolean;
     tags: Tag[];
     epicViewLog?: ViewLog;
     weeklyArticleHistory?: WeeklyArticleHistory;

--- a/types.ts
+++ b/types.ts
@@ -31,7 +31,6 @@ export type Targeting = {
     shouldHideReaderRevenue: boolean;
     isMinuteArticle: boolean;
     isPaidContent: boolean;
-    isSensitive?: boolean;
     tags: Tag[];
     epicViewLog?: ViewLog;
     weeklyArticleHistory?: WeeklyArticleHistory;

--- a/types.ts
+++ b/types.ts
@@ -27,7 +27,7 @@ export type WeeklyArticleHistory = WeeklyArticleLog[];
 
 export type Targeting = {
     contentType: string;
-    sectionName: string;
+    sectionName?: string;
     shouldHideReaderRevenue: boolean;
     isMinuteArticle: boolean;
     isPaidContent: boolean;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR makes the `sectionName` property in the `Targeting` type optional.

The `sectionName` property in the `Targeting` type doesn't appear in the [`ReaderRevenueBanner`](https://github.com/guardian/dotcom-rendering/blob/7ae84661b3b6ac357b2720c6cc4aea34932afd56/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx) payload on DCR (which, based on testing, doesn't seem to be under type control currently: once we resolve the type discrepancies we can change this), and is optionally an empty string in [`SlotBodyEnd`](https://github.com/guardian/dotcom-rendering/blob/7ae84661b3b6ac357b2720c6cc4aea34932afd56/src/web/components/SlotBodyEnd.tsx).

A [related PR](https://github.com/guardian/automat-client/pull/27) is the removal of the `ophanComponentId` property from the `tracking` type.

N.b. this PR formerly added `isSensitive` as a prop, but it's not  actually used on the platform so I will remove it there instead.