### PR TITLE
Add modulesVersion targeting field

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -44,6 +44,7 @@ export type Targeting = {
     showSupportMessaging: boolean;
     isRecurringContributor: boolean;
     lastOneOffContributionDate?: number; // Timestamp
+    modulesVersion?: string;
 };
 
 export type Metadata = {


### PR DESCRIPTION
Add support for Module versions by adding `modulesVersion` key type

See [here](https://github.com/guardian/support-dotcom-components#module-versions)

[PR for v2 modules](https://github.com/guardian/support-dotcom-components/pull/361)